### PR TITLE
Remove hours cap

### DIFF
--- a/humanize-slim/src/main/java/humanize/Humanize.java
+++ b/humanize-slim/src/main/java/humanize/Humanize.java
@@ -758,7 +758,7 @@ public final class Humanize
         int s = seconds.intValue();
         boolean neg = s < 0;
         s = Math.abs(s);
-        return style.format(context.get(), neg, (s / 3600) % 60, (s / 60) % 60, s % 60);
+        return style.format(context.get(), neg, s / 3600, (s / 60) % 60, s % 60);
     }
 
     /**

--- a/humanize-slim/src/test/java/humanize/TestHumanize.java
+++ b/humanize-slim/src/test/java/humanize/TestHumanize.java
@@ -184,6 +184,7 @@ public class TestHumanize
         assertEquals(duration(125, TimeStyle.FRENCH_DECIMAL), "2m 5s");
         assertEquals(duration(2015, TimeStyle.FRENCH_DECIMAL), "33m 35s");
 
+        assertEquals(duration(432061, TimeStyle.FRENCH_DECIMAL), "120h 1m 1s");
     }
 
     @Test
@@ -209,6 +210,7 @@ public class TestHumanize
         assertEquals(duration(125), "0:02:05");
         assertEquals(duration(2015), "0:33:35");
 
+        assertEquals(duration(432061), "120:01:01");
     }
 
     @Test


### PR DESCRIPTION
With the current modulo on hours, you can never display hours longer than 60.
My current duration in "9 days ago", but 42 hours was returned.
Maybe it's necessary to add a "days" count.